### PR TITLE
fix compiler warnings argv_split.h

### DIFF
--- a/argv_split.h
+++ b/argv_split.h
@@ -114,16 +114,13 @@ private:
 			
 			// find last whitespace before quote
 			w_front = cmdlinestr.find_last_of(space, q_front);
-			// none found?
-			if ( w_front == std::string::npos )
-				w_front = - 1;
 
 			pre_quoted_str = cmdlinestr.substr( w_front + 1, q_front - w_front - 1 );
 
 		}
 
 		// split by whitespace in [0, w_front[
-		if(w_front != -1 && w_front != std::string::npos)
+		if(w_front != std::string::npos)
 			splitStrToVectorBy(cmdlinestr.substr(0, w_front), SPACE_HEX_CODE, arguments);
 		
 		//add qouted string and surrounding
@@ -135,7 +132,7 @@ private:
 	}
 
 public:
-	argv_split() : quotes{ SGLQUOTE_HEX_CODE, DBLQUOTE_HEX_CODE, NULL}, space{ SPACE_HEX_CODE, NULL }, prependProgname(false) {}
+	argv_split() : prependProgname(false), quotes{ SGLQUOTE_HEX_CODE, DBLQUOTE_HEX_CODE, '\0'}, space{ SPACE_HEX_CODE, '\0' } {}
 
 	argv_split(std::string progname) : argv_split()
 	{


### PR DESCRIPTION
I don't see the point in doing `w_front = -1`, since `string::npos` is the same.
https://cplusplus.com/reference/string/string/npos/

```
In file included from main.cpp:1:
argv_split.h: In member function 'void argv_split::_parse(const std::string&)':
argv_split.h:126:28: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long long unsigned int'} and 'int' [-Wsign-compare]
  126 |                 if(w_front != -1 && w_front != std::string::npos)
      |                    ~~~~~~~~^~~~~
argv_split.h: In constructor 'argv_split::argv_split()':
argv_split.h:19:14: warning: 'argv_split::space' will be initialized after [-Wreorder]
   19 |         char space[2];
      |              ^~~~~
argv_split.h:13:14: warning:   'bool argv_split::prependProgname' [-Wreorder]
   13 |         bool prependProgname;
      |              ^~~~~~~~~~~~~~~
argv_split.h:138:9: warning:   when initialized here [-Wreorder]
  138 |         argv_split() : quotes{ SGLQUOTE_HEX_CODE, DBLQUOTE_HEX_CODE, NULL}, space{ SPACE_HEX_CODE, NULL }, prependProgname(false) {}
      |         ^~~~~~~~~~
argv_split.h:138:24: warning: converting to non-pointer type 'char' from NULL [-Wconversion-null]
  138 |         argv_split() : quotes{ SGLQUOTE_HEX_CODE, DBLQUOTE_HEX_CODE, NULL}, space{ SPACE_HEX_CODE, NULL }, prependProgname(false) {}
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argv_split.h:138:77: warning: converting to non-pointer type 'char' from NULL [-Wconversion-null]
  138 |         argv_split() : quotes{ SGLQUOTE_HEX_CODE, DBLQUOTE_HEX_CODE, NULL}, space{ SPACE_HEX_CODE, NULL }, prependProgname(false) {}
```