### PR TITLE
fix: undefined behaviour in findMatching

### DIFF
--- a/argv_split.h
+++ b/argv_split.h
@@ -44,8 +44,7 @@ private:
 	size_t findMatching(const std::string& str, size_t match_idx) {
 		if (match_idx == std::string::npos) return std::string::npos;
 		
-		char match[1];
-		match[0] = str.at( match_idx );
+		char match = str.at( match_idx );
 
 		size_t idx = match_idx;
 


### PR DESCRIPTION
was reproducable with

```cpp
#include "argv_split.h"

int main() {
    auto argv = argv_split("test");
    argv.parse("x=\"hello world\" -something=else");

    auto args = argv.argv();

    std::cout << args[0] << std::endl;
    std::cout << args[1] << std::endl;
}
```

and a recent gcc version and `-O3`.